### PR TITLE
Changed support OS (fedora) and updated tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,14 @@
 #
-# k2hdkc PHP Extension library
-# -----------------------------------------------------------------------
-# Utility tools for building configure/packages by AntPickax
+# K2HDKC PHP Extension library
 #
-# Copyright 2022 Yahoo Japan Corporation.
-#
-# AntPickax provides utility tools for supporting autotools
-# builds.
-#
-# These tools retrieve the necessary information from the
-# repository and appropriately set the setting values of
-# configure, Makefile, spec,etc file and so on.
-# These tools were recreated to reduce the number of fixes and
-# reduce the workload of developers when there is a change in
-# the project configuration.
-# -----------------------------------------------------------------------
-# 
 # Copyright 2023 Yahoo Japan Corporation.
 #
-# Modified to work with K2HDKC PHP Extension library. The original source 
-# code is from K2HASH PHP Extension library, which is distibuted under
-# MIT License as well as this program. See the LICENSE file for the full
-# copyright and license information
+# K2HDKC is k2hash based distributed KVS cluster.
+# K2HDKC uses K2HASH, CHMPX, FULLOCK libraries. K2HDKC supports
+# distributed KVS cluster server program and client libraries.
+#
+# For the full copyright and license information, please view
+# the license file that was distributed with this source code.
 #
 # AUTHOR:   Takeshi Nakatani
 # CREATE:   Fri, Feb 24 2022
@@ -74,8 +61,8 @@ jobs:
           - rockylinux:9
           - rockylinux:8
           - centos:centos7
+          - fedora:38
           - fedora:37
-          - fedora:36
           - alpine:3.18
 
         php:

--- a/.github/workflows/phpext_helper.sh
+++ b/.github/workflows/phpext_helper.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
-
-# k2hdkc PHP Extension library
-# -----------------------------------------------------------------------
+#
 # Utility tools for building configure/packages by AntPickax
 #
 # Copyright 2022 Yahoo Japan Corporation.
@@ -15,14 +13,9 @@
 # These tools were recreated to reduce the number of fixes and
 # reduce the workload of developers when there is a change in
 # the project configuration.
-# -----------------------------------------------------------------------
-# 
-# Copyright 2023 Yahoo Japan Corporation.
 #
-# Modified to work with K2HDKC PHP Extension library. The original source 
-# code is from K2HASH PHP Extension library, which is distibuted under
-# MIT License as well as this program. See the LICENSE file for the full
-# copyright and license information.
+# For the full copyright and license information, please view
+# the license file that was distributed with this source code.
 #
 # AUTHOR:   Takeshi Nakatani
 # CREATE:   Fri, Feb 24 2022
@@ -564,9 +557,47 @@ run_publish_package()
 			PRNERR "Token for uploading to packagecloud.io is not specified."
 			return 1
 		fi
-		if ! PACKAGECLOUD_TOKEN="${CI_PACKAGECLOUD_TOKEN}" /bin/sh -c "package_cloud push ${CI_PACKAGECLOUD_OWNER}/${CI_PACKAGECLOUD_PUBLISH_REPO}/${DIST_TAG} ${SRCTOP}/${PKG_OUTPUT_DIR}/*.${PKG_EXT}"; then
-			PRNERR "Failed to publish *.${PKG_EXT} packages to ${CI_PACKAGECLOUD_OWNER}/${CI_PACKAGECLOUD_PUBLISH_REPO}/${DIST_TAG}"
-			return 1
+
+		# [NOTE]
+		# The Ruby environment of some OS uses RVM (Ruby Version Manager) and requires a Bash shell environment.
+		#
+		if [ "${IS_OS_DEBIAN}" -eq 1 ] && echo "${CI_OSTYPE}" | sed -e 's#:##g' | grep -q -i -e 'debian10' -e 'debianbuster'; then
+			#
+			# Case for Debian 10(buster)
+			#
+			{
+				#
+				# Create bash script for run package_cloud command, because using RVM(Ruby Version Manager).
+				#
+				echo '#!/bin/bash'
+				echo ''
+				echo 'source /etc/profile.d/rvm.sh'
+				echo ''
+				echo 'if ! '"PACKAGECLOUD_TOKEN=${CI_PACKAGECLOUD_TOKEN} package_cloud push ${CI_PACKAGECLOUD_OWNER}/${CI_PACKAGECLOUD_PUBLISH_REPO}/${DIST_TAG} ${SRCTOP}/${PKG_OUTPUT_DIR}/*.${PKG_EXT}; then"
+				echo '	exit 1'
+				echo 'fi'
+				echo ''
+				echo 'exit 0'
+			} > /tmp/run_package_cloud.sh
+			chmod +x /tmp/run_package_cloud.sh
+
+			#
+			# Run bash script
+			#
+			if ({ RUNCMD /tmp/run_package_cloud.sh || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+				PRNERR "Failed to publish *.${PKG_EXT} packages to ${CI_PACKAGECLOUD_OWNER}/${CI_PACKAGECLOUD_PUBLISH_REPO}/${DIST_TAG}"
+				rm -f /tmp/run_package_cloud.sh
+				return 1
+			fi
+			rm -f /tmp/run_package_cloud.sh
+		else
+			#
+			# Case for other than Debian 10(buster)
+			#
+			if ! PACKAGECLOUD_TOKEN="${CI_PACKAGECLOUD_TOKEN}" /bin/sh -c "package_cloud push ${CI_PACKAGECLOUD_OWNER}/${CI_PACKAGECLOUD_PUBLISH_REPO}/${DIST_TAG} ${SRCTOP}/${PKG_OUTPUT_DIR}/*.${PKG_EXT}"; then
+				PRNERR "Failed to publish *.${PKG_EXT} packages to ${CI_PACKAGECLOUD_OWNER}/${CI_PACKAGECLOUD_PUBLISH_REPO}/${DIST_TAG}"
+				return 1
+			fi
 		fi
 	else
 		PRNINFO "Not need to publish packages"
@@ -898,7 +929,7 @@ PRNSUCCESS "Start to check options and environments"
 PRE_CLEANUP_FILES_DIRS=""
 
 CPPCHECK_TARGET="."
-CPPCHECK_BASE_OPT="--quiet --error-exitcode=1 --inline-suppr -j 4 --std=c++03 --xml --enable=warning,style,information,missingInclude"
+CPPCHECK_BASE_OPT="--quiet --error-exitcode=1 --inline-suppr -j 4 --std=c++03 --xml"
 CPPCHECK_ENABLE_VALUES="warning style information missingInclude"
 CPPCHECK_IGNORE_VALUES="unmatchedSuppression"
 CPPCHECK_BUILD_DIR="/tmp/cppcheck"
@@ -1310,7 +1341,24 @@ PRNTITLE "Install PHP packages"
 
 if [ -n "${INSTALL_PHP_PKG_LIST}" ]; then
 	PRNINFO "Install packages"
-	if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" "${INSTALL_PHP_OPT}" "${INSTALL_PHP_PKG_LIST}" || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+
+	# [NOTE]
+	# The REMI repository is sometimes unstable and packages may be missing.
+	# Take that into consideration and try again if it fails.
+	#
+	_INSTALL_RETRY=5
+	while [ "${_INSTALL_RETRY}" -gt 0 ]; do
+		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" "${INSTALL_PHP_OPT}" "${INSTALL_PHP_PKG_LIST}" || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			if [ "${_INSTALL_RETRY}" -gt 1 ]; then
+				PRNWARN "Failed to install PHP packages, but retry to install after wait."
+				sleep 30
+			fi
+		else
+			break
+		fi
+		_INSTALL_RETRY=$((_INSTALL_RETRY - 1))
+	done
+	if [ "${_INSTALL_RETRY}" -le 0 ]; then
 		PRNERR "Failed to install PHP packages"
 		exit 1
 	fi
@@ -1360,11 +1408,11 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 			PRNERR "Failed to install SCL packages"
 			exit 1
 		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" rh-ruby24 rh-ruby24-ruby-devel rh-ruby24-rubygem-rake || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" rh-ruby26 rh-ruby26-ruby-devel rh-ruby26-rubygem-rake || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 			PRNERR "Failed to install ruby packages"
 			exit 1
 		fi
-		. /opt/rh/rh-ruby24/enable
+		. /opt/rh/rh-ruby26/enable
 
 		if ({ RUNCMD "${GEM_BIN}" "${GEM_INSTALL_CMD}" package_cloud || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 			PRNERR "Failed to install packagecloud.io upload tools"
@@ -1380,9 +1428,128 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 			exit 1
 		fi
 
+	elif [ "${IS_OS_ROCKY}" -eq 1 ] && echo "${CI_OSTYPE}" | sed -e 's#:##g' | grep -q -i -e 'rockylinux8' -e 'rocky8'; then
+		#
+		# Case for Rocky Linux 8 (default ruby 2.5)
+		#
+
+		#
+		# Switch ruby module
+		#
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" reset ruby || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to reset ruby module"
+			exit 1
+		fi
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" install ruby:2.6 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to install ruby 2.6 module"
+			exit 1
+		fi
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" enable ruby:2.6 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to enable ruby 2.6 module"
+			exit 1
+		fi
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" update ruby:2.6 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to update ruby 2.6 module"
+			exit 1
+		fi
+
+		#
+		# Install package_cloud tool
+		#
+		if ({ RUNCMD "${GEM_BIN}" "${GEM_INSTALL_CMD}" package_cloud || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to install packagecloud.io upload tools"
+			exit 1
+		fi
+
+	elif [ "${IS_OS_DEBIAN}" -eq 1 ] && echo "${CI_OSTYPE}" | sed -e 's#:##g' | grep -q -i -e 'debian10' -e 'debianbuster'; then
+		#
+		# Case for Debian 10/buster (default ruby 2.5)
+		#
+
+		#
+		# Set RVM(Ruby Version Manager) and install Ruby 2.6 and package_cloud
+		#
+		# [NOTE]
+		# Install Ruby2.6 using RVM tools.
+		# Installation and running RVM tools must be done in Bash.
+		# This set of installations will create a Bash script and run it.
+		#
+		# The script does the following:
+		# First, we need to install the GPG key before installing RVM.
+		# This is done with one of the following commands:
+		#
+		#	sudo gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+		#		or
+		#	command curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
+		#	command curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg --import -
+		#
+		# After that, install RVM installation, RVM environment settings, Ruby2.6 installation, and package_cloud tools.
+		#
+		# [NOTE]
+		# The RVM installation requires running from a bash shell.
+		# So create a Bash script and run it.
+		{
+			echo '#!/bin/bash'
+			echo ''
+			echo 'if ! curl -sSL https://rvm.io/mpapis.asc | gpg --import - 2>&1; then'
+			echo '	echo "Failed to run [ curl -sSL https://rvm.io/mpapis.asc | gpg --import - ] command."'
+			echo '	exit 1'
+			echo 'fi'
+			echo 'if ! curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - 2>&1; then'
+			echo '	echo "Failed to run [ curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - ] command."'
+			echo '	exit 1'
+			echo 'fi'
+			echo ''
+			echo 'if ! curl -sSL https://get.rvm.io | bash -s stable --ruby 2>&1; then'
+			echo '	echo "Failed to install RVM tool."'
+			echo '	exit 1'
+			echo 'fi'
+			echo ''
+			echo 'if [ ! -f /etc/profile.d/rvm.sh ]; then'
+			echo '	echo "Not found /etc/profile.d/rvm.sh file."'
+			echo '	exit 1'
+			echo 'fi'
+			echo 'source /etc/profile.d/rvm.sh'
+			echo ''
+			echo 'if ! rvm get stable --autolibs=enable 2>&1; then'
+			echo '	echo "Failed to get/update RVM stable."'
+			echo '	exit 1'
+			echo 'fi'
+			echo 'if ! usermod -a -G rvm root 2>&1; then'
+			echo '	echo "Failed to add rvm user to root group."'
+			echo '	exit 1'
+			echo 'fi'
+			echo 'if ! rvm install ruby-2.6 2>&1; then'
+			echo '	echo "Failed to install ruby 2.6."'
+			echo '	exit 1'
+			echo 'fi'
+			echo 'if ! rvm --default use ruby-2.6 2>&1; then'
+			echo '	echo "Failed to set ruby 2.6 as default."'
+			echo '	exit 1'
+			echo 'fi'
+			echo ''
+			echo 'if ! '"${GEM_BIN} ${GEM_INSTALL_CMD} package_cloud 2>&1; then"
+			echo '	echo "Failed to install packagecloud.io upload tools"'
+			echo '	exit 1'
+			echo 'fi'
+			echo ''
+			echo 'exit 0'
+		} > /tmp/rvm_setup.sh
+		chmod +x /tmp/rvm_setup.sh
+
+		#
+		# Run bash script
+		#
+		if ({ RUNCMD /tmp/rvm_setup.sh || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to set up RVM."
+			rm -f /tmp/rvm_setup.sh
+			exit 1
+		fi
+		rm -f /tmp/rvm_setup.sh
+
 	else
 		#
-		# Case for other than CentOS
+		# Case for other than CentOS / Alpine / Debian 10 / Rocky Linux 8
 		#
 		if ({ RUNCMD "${GEM_BIN}" "${GEM_INSTALL_CMD}" rake package_cloud || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 			PRNERR "Failed to install packagecloud.io upload tools"

--- a/.github/workflows/phpexttypevars.sh
+++ b/.github/workflows/phpexttypevars.sh
@@ -1,24 +1,14 @@
 #
-# k2hdkc PHP Extension library
-# -----------------------------------------------------------------------
-# K2HASH PHP Extension library
-#
-# Copyright 2022 Yahoo Japan Corporation.
-#
-# K2HASH is key-valuew store base libraries.
-# K2HASH is made for the purpose of the construction of
-# original KVS system and the offer of the library.
-# The characteristic is this KVS library which Key can
-# layer. And can support multi-processing and multi-thread,
-# and is provided safely as available KVS.
-# -----------------------------------------------------------------------
+# K2HDKC PHP Extension library
 #
 # Copyright 2023 Yahoo Japan Corporation.
 #
-# Modified to work with K2HDKC PHP Extension library. The original source 
-# code is from K2HASH PHP Extension library, which is distibuted under
-# MIT License as well as this program. See the LICENSE file for the full
-# copyright and license information.
+# K2HDKC is k2hash based distributed KVS cluster.
+# K2HDKC uses K2HASH, CHMPX, FULLOCK libraries. K2HDKC supports
+# distributed KVS cluster server program and client libraries.
+# 
+# For the full copyright and license information, please view
+# the license file that was distributed with this source code.
 #
 # AUTHOR:   Takeshi Nakatani
 # CREATE:   Fri, Feb 24 2022
@@ -212,30 +202,6 @@ elif [ "${CI_OSTYPE}" = "ubuntu:20.04" ] || [ "${CI_OSTYPE}" = "ubuntu:focal" ];
 
 	IS_OS_UBUNTU=1
 
-elif [ "${CI_OSTYPE}" = "ubuntu:18.04" ] || [ "${CI_OSTYPE}" = "ubuntu:bionic" ]; then
-	DIST_TAG="ubuntu/bionic"
-	PKG_EXT="deb"
-	PKG_OUTPUT_DIR="packages"
-
-	INSTALLER_BIN="apt-get"
-	UPDATE_CMD="update"
-	UPDATE_CMD_ARG=""
-	INSTALL_CMD="install"
-	INSTALL_CMD_ARG=""
-	INSTALL_AUTO_ARG="-y"
-	INSTALL_QUIET_ARG="-qq"
-	INSTALL_PKG_LIST="git lintian debhelper pkg-config ruby-dev rubygems rubygems-integration procps shtool k2hdkc-dev"
-
-	INSTALL_PHP_PRE_ADD_REPO="ca-certificates apt-transport-https software-properties-common"
-	INSTALL_PHP_REPO="ppa:ondrej/php"
-	INSTALL_PHP_PKG_LIST="dh-php php${PHPVER_WITHPERIOD} php${PHPVER_WITHPERIOD}-dev libapache2-mod-php${PHPVER_WITHPERIOD}"
-	INSTALL_PHP_OPT=""
-	INSTALL_PHP_POST_CONFIG="update-alternatives --set php-config /usr/bin/php-config${PHPVER_WITHPERIOD}"
-	INSTALL_PHP_POST_BIN="update-alternatives --set php /usr/bin/php${PHPVER_WITHPERIOD}"
-	SWITCH_PHP_COMMAND=""
-
-	IS_OS_UBUNTU=1
-
 elif [ "${CI_OSTYPE}" = "debian:12" ] || [ "${CI_OSTYPE}" = "debian:bookworm" ]; then
 	DIST_TAG="debian/bookworm"
 	PKG_EXT="deb"
@@ -405,6 +371,30 @@ elif [ "${CI_OSTYPE}" = "centos:7" ] || [ "${CI_OSTYPE}" = "centos:centos7" ]; t
 
 	IS_OS_CENTOS=1
 
+elif [ "${CI_OSTYPE}" = "fedora:38" ]; then
+	DIST_TAG="fedora/38"
+	PKG_EXT="rpm"
+	PKG_OUTPUT_DIR="packages"
+
+	INSTALLER_BIN="dnf"
+	UPDATE_CMD="update"
+	UPDATE_CMD_ARG=""
+	INSTALL_CMD="install"
+	INSTALL_CMD_ARG=""
+	INSTALL_AUTO_ARG="-y"
+	INSTALL_QUIET_ARG="-q"
+	INSTALL_PKG_LIST="git make diffutils pkgconfig patch yum-utils rpmdevtools redhat-rpm-config rpm-build rpm-devel rpmlint scl-utils-build ruby-devel rubygems procps python3 k2hdkc-devel"
+
+	INSTALL_PHP_PRE_ADD_REPO=""
+	INSTALL_PHP_REPO="https://rpms.remirepo.net/fedora/remi-release-38.rpm"
+	INSTALL_PHP_PKG_LIST="php${PHPVER_NOPERIOD}-php-devel php${PHPVER_NOPERIOD}-scldevel php${PHPVER_NOPERIOD}-build"
+	INSTALL_PHP_OPT=""
+	INSTALL_PHP_POST_CONFIG=""
+	INSTALL_PHP_POST_BIN=""
+	SWITCH_PHP_COMMAND="scl enable php${PHPVER_NOPERIOD} --"
+
+	IS_OS_FEDORA=1
+
 elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
 	DIST_TAG="fedora/37"
 	PKG_EXT="rpm"
@@ -421,30 +411,6 @@ elif [ "${CI_OSTYPE}" = "fedora:37" ]; then
 
 	INSTALL_PHP_PRE_ADD_REPO=""
 	INSTALL_PHP_REPO="https://rpms.remirepo.net/fedora/remi-release-37.rpm"
-	INSTALL_PHP_PKG_LIST="php${PHPVER_NOPERIOD}-php-devel php${PHPVER_NOPERIOD}-scldevel php${PHPVER_NOPERIOD}-build"
-	INSTALL_PHP_OPT=""
-	INSTALL_PHP_POST_CONFIG=""
-	INSTALL_PHP_POST_BIN=""
-	SWITCH_PHP_COMMAND="scl enable php${PHPVER_NOPERIOD} --"
-
-	IS_OS_FEDORA=1
-
-elif [ "${CI_OSTYPE}" = "fedora:36" ]; then
-	DIST_TAG="fedora/36"
-	PKG_EXT="rpm"
-	PKG_OUTPUT_DIR="packages"
-
-	INSTALLER_BIN="dnf"
-	UPDATE_CMD="update"
-	UPDATE_CMD_ARG=""
-	INSTALL_CMD="install"
-	INSTALL_CMD_ARG=""
-	INSTALL_AUTO_ARG="-y"
-	INSTALL_QUIET_ARG="-q"
-	INSTALL_PKG_LIST="git make diffutils pkgconfig patch yum-utils rpmdevtools redhat-rpm-config rpm-build rpm-devel rpmlint scl-utils-build ruby-devel rubygems procps python3 k2hdkc-devel"
-
-	INSTALL_PHP_PRE_ADD_REPO=""
-	INSTALL_PHP_REPO="https://rpms.remirepo.net/fedora/remi-release-36.rpm"
 	INSTALL_PHP_PKG_LIST="php${PHPVER_NOPERIOD}-php-devel php${PHPVER_NOPERIOD}-scldevel php${PHPVER_NOPERIOD}-build"
 	INSTALL_PHP_OPT=""
 	INSTALL_PHP_POST_CONFIG=""

--- a/k2hdkcpx.c
+++ b/k2hdkcpx.c
@@ -21,7 +21,9 @@
 # include "config.h"
 #endif
 
+// cppcheck-suppress missingInclude
 #include "php.h"
+// cppcheck-suppress missingInclude
 #include "ext/standard/info.h"
 #include "php_k2hdkcpx.h"
 

--- a/k2hdkcpx_func.c
+++ b/k2hdkcpx_func.c
@@ -22,7 +22,9 @@
 #endif
 
 
+// cppcheck-suppress missingInclude
 #include "php.h"
+// cppcheck-suppress missingInclude
 #include "ext/standard/info.h"
 #include "php_k2hdkcpx.h"
 #include "k2hdkcpx_compat.h"

--- a/php_k2hdkcpx.h
+++ b/php_k2hdkcpx.h
@@ -18,12 +18,13 @@
 */
 
 #ifndef PHP_K2HDKCPX_H
-# define PHP_K2HDKCPX_H
+#define PHP_K2HDKCPX_H
 
+// cppcheck-suppress missingInclude
 #include "k2hdkc.h"
 #include "config.h"
 
-# define DEFAULT_PORT 8031
+#define DEFAULT_PORT 8031
 
 // cppcheck-suppress unknownMacro
 ZEND_BEGIN_MODULE_GLOBALS(k2hdkcpx);
@@ -45,10 +46,10 @@ void k2hdkcpx_update_property_resource(zend_class_entry* scope, zval* object, co
 
 // # define PHP_K2HDKCPX_VERSION "0.1.0"
 
-# if defined(ZTS) && defined(COMPILE_DL_K2HDKCPX)
+#if defined(ZTS) && defined(COMPILE_DL_K2HDKCPX)
 // cppcheck-suppress unknownMacro
 ZEND_TSRMLS_CACHE_EXTERN()
-# endif
+#endif
 
 #endif	/* PHP_K2HDKCPX_H */
 


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
- Supported OS has been changed.  
Does not support fedora 36  
Added support for fedora 38  

- Fixed `phpext_helper.sh`  
The minimum Ruby version required for the `package_cloud` command has been changed to 2.6, and `phpext_helper.sh` has been modified accordingly.

- Fixed errors about `cppcheck`.